### PR TITLE
Changed user so it would work with UniFi Protect v1.6.0

### DIFF
--- a/unifi-protect-mqtt.service
+++ b/unifi-protect-mqtt.service
@@ -3,7 +3,7 @@ Description=Unifi Protect Motion Detection to MQTT
 After=network.target
 
 [Service]
-User=ubnt
+User=unifi-protect
 Restart=always
 RestartSec=5
 Type=simple


### PR DESCRIPTION
The user ubnt does not exist (if you change the login name in your controller). As UniFi protect runs under `unifi-protect` the logfiles are readably by this account.